### PR TITLE
Fix getIntervalHistogram returning empty histogram

### DIFF
--- a/src/main/java/org/HdrHistogram/IntervalHistogramRecorder.java
+++ b/src/main/java/org/HdrHistogram/IntervalHistogramRecorder.java
@@ -121,7 +121,7 @@ public class IntervalHistogramRecorder {
      */
     public synchronized Histogram getIntervalHistogram() {
         Histogram intervalHistogram = new Histogram(inactiveHistogram);
-        getIntervalHistogramInto(new Histogram(inactiveHistogram));
+        getIntervalHistogramInto(intervalHistogram);
         return intervalHistogram;
     }
 


### PR DESCRIPTION
The previous version of this class calls getIntervalHistogramInto on the newly created intervalHistogram. That is the correct behavior. Or so I assume, since the javadocs say the Histogram constructor _doesn't_ copy the histogram data.
