### PR TITLE
Added Left-Right guard to compare with WriterReaderPhaser

### DIFF
--- a/src/main/java/org/HdrHistogram/IntervalHistogramRecorderLR.java
+++ b/src/main/java/org/HdrHistogram/IntervalHistogramRecorderLR.java
@@ -1,0 +1,172 @@
+/**
+ * Written by Gil Tene of Azul Systems, and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * @author Gil Tene
+ */
+
+package org.HdrHistogram;
+
+/**
+ * {@link IntervalHistogramRecorder} records values, and provides stable interval histograms from
+ * live recorded data without interrupting or stalling active recording of values. Each interval
+ * histogram provided contains all value counts accumulated since the previous interval histogram
+ * was taken.
+ * <p>
+ * This pattern is commonly used in logging interval histogram information while recoding is ongoing.
+ * <p>
+ * {@link IntervalHistogramRecorder} supports concurrent
+ * {@link org.HdrHistogram.IntervalHistogramRecorder#recordValue} or
+ * {@link org.HdrHistogram.IntervalHistogramRecorder#recordValueWithExpectedInterval} calls.
+ * Recording calls are wait-free on architectures that support atomic increment operations, and
+ * are lock-free on architectures that do no.
+ *
+ */
+
+public class IntervalHistogramRecorderLR {
+
+    private final LeftRightGuardLongAdder<AtomicHistogram> recordingPhaser = new LeftRightGuardLongAdder<AtomicHistogram>(null, null);
+
+    private volatile AtomicHistogram activeHistogram;
+    private AtomicHistogram inactiveHistogram;
+
+    /**
+     * Construct a DoubleBufferedHistogram given the highest value to be tracked and a number of significant
+     * decimal digits. The histogram will be constructed to implicitly track (distinguish from 0) values as low as 1.
+     *
+     * @param highestTrackableValue The highest value to be tracked by the histogram. Must be a positive
+     *                              integer that is {@literal >=} 2.
+     * @param numberOfSignificantValueDigits The number of significant decimal digits to which the histogram will
+     *                                       maintain value resolution and separation. Must be a non-negative
+     *                                       integer between 0 and 5.
+     */
+    public IntervalHistogramRecorderLR(final long highestTrackableValue,
+                                       final int numberOfSignificantValueDigits) {
+        this(1, highestTrackableValue, numberOfSignificantValueDigits);
+    }
+
+    /**
+     * Construct a DoubleBufferedHistogram given the Lowest and highest values to be tracked and a number
+     * of significant decimal digits. Providing a lowestDiscernibleValue is useful is situations where the units used
+     * for the histogram's values are much smaller that the minimal accuracy required. E.g. when tracking
+     * time values stated in nanosecond units, where the minimal accuracy required is a microsecond, the
+     * proper value for lowestDiscernibleValue would be 1000.
+     *
+     * @param lowestDiscernibleValue The lowest value that can be tracked (distinguished from 0) by the histogram.
+     *                             Must be a positive integer that is {@literal >=} 1. May be internally rounded down to nearest
+     *                             power of 2.
+     * @param highestTrackableValue The highest value to be tracked by the histogram. Must be a positive
+     *                              integer that is {@literal >=} (2 * lowestDiscernibleValue).
+     * @param numberOfSignificantValueDigits The number of significant decimal digits to which the histogram will
+     *                                       maintain value resolution and separation. Must be a non-negative
+     *                                       integer between 0 and 5.
+     */
+    public IntervalHistogramRecorderLR(final long lowestDiscernibleValue,
+                                       final long highestTrackableValue,
+                                       final int numberOfSignificantValueDigits) {
+        activeHistogram = new AtomicHistogram(
+                lowestDiscernibleValue, highestTrackableValue, numberOfSignificantValueDigits);
+        inactiveHistogram = new AtomicHistogram(
+                lowestDiscernibleValue, highestTrackableValue, numberOfSignificantValueDigits);
+    }
+
+    /**
+     * Record a value
+     * @param value the value to record
+     * @throws ArrayIndexOutOfBoundsException (may throw) if value is exceeds highestTrackableValue
+     */
+    public void recordValue(long value) {
+        int criticalValueAtEnter = recordingPhaser.arrive();
+        try {
+            activeHistogram.recordValue(value);
+        } finally {
+            recordingPhaser.depart(criticalValueAtEnter);
+        }
+    }
+
+    /**
+     * Record a value
+     * <p>
+     * To compensate for the loss of sampled values when a recorded value is larger than the expected
+     * interval between value samples, Histogram will auto-generate an additional series of decreasingly-smaller
+     * (down to the expectedIntervalBetweenValueSamples) value records.
+     * <p>
+     * See related notes {@link AbstractHistogram#recordValueWithExpectedInterval(long, long)}
+     * for more explanations about coordinated opmissionand expetced interval correction.
+     *      *
+     * @param value The value to record
+     * @param expectedIntervalBetweenValueSamples If expectedIntervalBetweenValueSamples is larger than 0, add
+     *                                           auto-generated value records as appropriate if value is larger
+     *                                           than expectedIntervalBetweenValueSamples
+     * @throws ArrayIndexOutOfBoundsException (may throw) if value is exceeds highestTrackableValue
+     */
+    public void recordValueWithExpectedInterval(final long value, final long expectedIntervalBetweenValueSamples)
+            throws ArrayIndexOutOfBoundsException {
+        int criticalValueAtEnter = recordingPhaser.arrive();
+        try {
+            activeHistogram.recordValueWithExpectedInterval(value, expectedIntervalBetweenValueSamples);
+        } finally {
+            recordingPhaser.depart(criticalValueAtEnter);
+        }
+    }
+
+    /**
+     * Get a new interval histogram, which will include a stable, consistent view of all value counts
+     * accumulated since the last interval histogram was taken.
+     * <p>
+     * Calling {@link org.HdrHistogram.IntervalHistogramRecorder#getIntervalHistogram}() will reset
+     * the value counts, and start accumulating value counts for the next interval.
+     *
+     * @return a histogram containing the value counts accumulated since the last interval histogram was taken.
+     */
+    public synchronized Histogram getIntervalHistogram() {
+        Histogram intervalHistogram = new Histogram(inactiveHistogram);
+        getIntervalHistogramInto(intervalHistogram);
+        return intervalHistogram;
+    }
+
+    /**
+     * Place a copy of the value counts accumulated since accumulated (since the last interval histogram
+     * was taken) into {@code targetHistogram}.
+     *
+     * Calling {@link org.HdrHistogram.IntervalHistogramRecorder#getIntervalHistogramInto}() will reset
+     * the value counts, and start accumulating value counts for the next interval.
+     *
+     * @param targetHistogram the histogram into which the interval histogram's data should be copied
+     */
+    public synchronized void getIntervalHistogramInto(AbstractHistogram targetHistogram) {
+        performIntervalSample();
+        inactiveHistogram.copyInto(targetHistogram);
+    }
+
+    public synchronized void reset() {
+        // the currently inactive histogram is reset each time we flip. So flipping twice resets both:
+        performIntervalSample();
+        performIntervalSample();
+    }
+
+    private void performIntervalSample() {
+        inactiveHistogram.reset();
+        try {
+            recordingPhaser.writeLock(); // not really needed
+
+            // Swap active and inactive histograms:
+            final AtomicHistogram tempHistogram = inactiveHistogram;
+            inactiveHistogram = activeHistogram;
+            activeHistogram = tempHistogram;
+
+            // Mark end time of previous interval and start time of new one:
+            long now = System.currentTimeMillis();
+            activeHistogram.setStartTimeStamp(now);
+            inactiveHistogram.setEndTimeStamp(now);
+
+            // Make sure we are not in the middle of recording a value on the previously active histogram:
+
+            // Flip phase to make sure no recordings that were in flight pre-flip are still active:
+            //recordingPhaser.flipPhase(500000L /* yield in 0.5 msec units if needed */);
+            recordingPhaser.toggleVersionAndScan();
+        } finally {
+            recordingPhaser.writeUnlock(); // not really needed
+        }
+    }
+}

--- a/src/main/java/org/HdrHistogram/LeftRightGuardLongAdder.java
+++ b/src/main/java/org/HdrHistogram/LeftRightGuardLongAdder.java
@@ -1,0 +1,223 @@
+package org.HdrHistogram;
+/******************************************************************************
+ * Copyright (c) 2011-2013, Pedro Ramalhete and Andreia Correia
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the author nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************
+ */ 
+
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.StampedLock;
+
+
+/** <h1>Left-Right pattern with Guard</h1>
+ * A Thread-safe Guard pattern that has 
+ * Wait-Free Population-Oblivious properties for Reads.
+ * <p>
+ * Follows the algorithm described in the paper "Left-Right: A Concurrency 
+ * Control Technique with Wait-Free Population Oblivious Reads" using
+ * the ingress/egress ReadIndicator with two LongAdder instances each (4 in 
+ * total). See this description here:
+ * http://concurrencyfreaks.com/2014/11/a-catalog-of-read-indicators.html
+ * <p>
+ * This class allows easy usage of the Left-Right pattern as if it was a 
+ * Reader-Writer Lock (but Read operations will not be "Blocking"). 
+ * The main disadvantage compared with a "normal" Reader-Writer Lock is that 
+ * this needs to be associated to the object (or pair of objects) that it 
+ * is protecting. 
+ * <p>
+ * Example:
+ * - Initialize with two equal instances of whatever it is you want to protect:
+ *   guard = new LeftRightGuardLongAdder<UserClass>(new UserClass(), new UserClass());
+ *   
+ * - To access in read-only mode do something like this:
+ *      final UserClass userInstance = guard.arrive();
+ *      userInstance.readDataFromObject();        
+ *      guard.depart();
+ * 
+ * - To access in write-modify mode:
+ *      UserClass userInstance = guard.writeLock();
+ *      userInstance.modifyThisObject();
+ *      userInstance = guard.writeToggle();
+ *      userInstance.modifyThisObject();
+ *      guard.writeUnlock();
+ *      
+ * The exact same operations must be done on the instance before and after 
+ * guard.writeToggle(), which means that those operations should have no
+ * "side-effects" outside of the instance.
+ * <p>
+ * 
+ * @author Pedro Ramalhete
+ * @author Andreia Correia
+ */
+public class LeftRightGuardLongAdder<E> implements java.io.Serializable {
+	
+    private static final long serialVersionUID = 305428461165246526L;
+
+    // States of the leftRight variable
+    private final static int READS_ON_LEFT  = -1;
+    private final static int READS_ON_RIGHT = 1;
+    // States of versionIndex
+    private final static int VERSION0 = -1;
+    private final static int VERSION1 = 1;
+    
+    private final E leftInstance;
+    private final E rightInstance;
+    
+    private transient final AtomicInteger leftRight;
+    private transient final AtomicInteger versionIndex;
+    
+    private transient final LongAdder readersIngressv0;
+    private transient final LongAdder readersIngressv1;
+    private transient final LongAdder readersEgressv0;
+    private transient final LongAdder readersEgressv1;
+            
+    private transient final StampedLock writeLock;
+    
+    
+    /**
+     * Default constructor.
+     * Must pass the two instances that will be used on the Left-Right pattern.
+     */
+    public LeftRightGuardLongAdder(E leftInstance, E rightInstance) {
+        this.leftInstance  = leftInstance;
+        this.rightInstance = rightInstance;
+        
+        // Only "Write" operations can modify these
+        leftRight    = new AtomicInteger(READS_ON_LEFT);
+        versionIndex = new AtomicInteger(VERSION0);
+
+        readersIngressv0 = new LongAdder();
+        readersIngressv1 = new LongAdder();
+        readersEgressv0 = new LongAdder();
+        readersEgressv1 = new LongAdder();
+
+        writeLock = new StampedLock();
+    }
+
+
+    private boolean isEmpty(int localVersionIndex) {
+        if (localVersionIndex == VERSION0) {
+            return (readersEgressv0.sum() == readersIngressv0.sum());   
+        } else {
+            return (readersEgressv1.sum() == readersIngressv1.sum());
+        }
+    }
+    
+    
+    /**
+     * Waits for all the threads doing a "Read" to finish their tasks on the 
+     * TreeMap that the "Write" wants to modify.  
+     * Must be called only by "Write" operations, and it {@code mutex} must 
+     * be locked when this function is called.
+     */
+    public void toggleVersionAndScan() {
+        final int prevVersionIndex = versionIndex.get(); 
+        final int nextVersionIndex = -prevVersionIndex;
+                
+        // Wait for Readers from next version
+        while (!isEmpty(nextVersionIndex)) Thread.yield();
+
+        // Toggle versionIndex
+        versionIndex.set(nextVersionIndex);   
+        
+        // Wait for Readers from previous version
+        while (!isEmpty(prevVersionIndex)) Thread.yield();
+    }   
+    
+       
+
+    /**
+     * 
+     * @return
+     */
+    public final int arrive() {
+        final int localVersionIndex = versionIndex.get();
+    	if (localVersionIndex == VERSION0) {
+    	    readersIngressv0.increment();
+    	} else {
+    	    readersIngressv1.increment();
+    	}
+        return localVersionIndex;
+    }
+    
+    
+    /**
+     * 
+     */
+    public final void depart(int localVersionIndex) {
+        if (localVersionIndex == VERSION0) {
+            readersEgressv0.increment();
+        } else {
+            readersEgressv1.increment();
+        }
+    }
+
+    
+    /**
+     * 
+     * @return the instance that is to be used in the first step, until 
+     * writeToggle() is called
+     */
+    public final E writeLock() {
+    	writeLock.asWriteLock().lock();    	
+        // Do the operation in the first Tree, opposite to the one currently 
+        // being used by the Read operations. No need to wait.
+        if (leftRight.get() == READS_ON_LEFT) {
+            return rightInstance;
+        } else {
+            return leftInstance;
+        }    	
+    }
+    
+    
+    /**
+     * 
+     * @return the instance that is to be used in the second step, until
+     * writeUnlock() is called
+     */
+    public final E writeToggle() {
+        // Toggle leftRight and wait for currently running Readers
+    	final int nextLeftRight = -leftRight.get();
+        leftRight.set(nextLeftRight);	
+        toggleVersionAndScan();
+        
+        if (nextLeftRight == READS_ON_LEFT) {
+            return rightInstance;
+        } else {
+            return leftInstance;
+        }    	
+    }
+    
+    
+    /**
+     * 
+     */
+    public final void writeUnlock() {
+    	writeLock.asWriteLock().unlock();
+    }
+
+}


### PR DESCRIPTION
Hi,
I've added a Left-Right pattern with a Ingress/Egress ReadIndicator using LongAdder counters to reduce contention (and false-sharing) as needed on the arrive() method.
http://concurrencyfreaks.com/2014/11/a-catalog-of-read-indicators.html

I did some performance measurements against WriterReaderPhaser but for this scenario the gains were very small, because it seems that the bottleneck is on the counters of the histogram itself, and therefore, improving the arrive() does little benefit.

Feel free to disregard this pull request, it's just to show that any variant of the Left-Right is a replacement for WriterReaderPhaser, because the WriterReaderPhaser is also a variant of Left-Right  ;)