### PR TITLE
setAutoResize(true) in HistogramLogProcessor

### DIFF
--- a/src/main/java/org/HdrHistogram/HistogramLogProcessor.java
+++ b/src/main/java/org/HdrHistogram/HistogramLogProcessor.java
@@ -188,9 +188,11 @@ public class HistogramLogProcessor extends Thread {
             if (intervalHistogram instanceof DoubleHistogram) {
                 accumulatedDoubleHistogram = ((DoubleHistogram) intervalHistogram).copy();
                 accumulatedDoubleHistogram.reset();
+                accumulatedDoubleHistogram.setAutoResize(true);
             } else {
                 accumulatedRegularHistogram = ((Histogram) intervalHistogram).copy();
                 accumulatedRegularHistogram.reset();
+                accumulatedRegularHistogram.setAutoResize(true);
             }
         }
 


### PR DESCRIPTION
Otherwise the HistogramLogProcessor may fail on otherwise reasonable
inputs with ArrayIndexOutOfBoundsException from
- `AbstractHistogram.java:567`
- `HistogramLogProcessor.java:207`

fixes #47
