### PR TITLE
Fix ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/org/HdrHistogram/AbstractHistogram.java
+++ b/src/main/java/org/HdrHistogram/AbstractHistogram.java
@@ -1695,8 +1695,9 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
     synchronized public int encodeIntoCompressedByteBuffer(
             final ByteBuffer targetBuffer,
             final int compressionLevel) {
-        if (intermediateUncompressedByteBuffer == null) {
-            intermediateUncompressedByteBuffer = ByteBuffer.allocate(getNeededByteBufferCapacity(countsArrayLength));
+        int neededCapacity = getNeededByteBufferCapacity(countsArrayLength);
+        if (intermediateUncompressedByteBuffer == null || intermediateUncompressedByteBuffer.capacity() < neededCapacity) {
+            intermediateUncompressedByteBuffer = ByteBuffer.allocate(neededCapacity);
         }
         intermediateUncompressedByteBuffer.clear();
         final int uncompressedLength = encodeIntoByteBuffer(intermediateUncompressedByteBuffer);

--- a/src/test/java/org/HdrHistogram/HistogramEncodingTest.java
+++ b/src/test/java/org/HdrHistogram/HistogramEncodingTest.java
@@ -194,4 +194,23 @@ public class HistogramEncodingTest {
 
         Assert.assertEquals(histogram, decodedHistogram);
     }
+
+    @Test
+    public void testResizingHistogramBetweenCompressedEncodings() throws Exception {
+        Histogram histogram = new Histogram(3);
+
+        histogram.recordValue(1);
+
+        ByteBuffer targetCompressedBuffer = ByteBuffer.allocate(histogram.getNeededByteBufferCapacity());
+        histogram.encodeIntoCompressedByteBuffer(targetCompressedBuffer);
+
+        histogram.recordValue(10000);
+
+        targetCompressedBuffer = ByteBuffer.allocate(histogram.getNeededByteBufferCapacity());
+        histogram.encodeIntoCompressedByteBuffer(targetCompressedBuffer);
+        targetCompressedBuffer.rewind();
+
+        Histogram histogram2 = Histogram.decodeFromCompressedByteBuffer(targetCompressedBuffer, 0);
+        Assert.assertEquals(histogram, histogram2);
+    }
 }


### PR DESCRIPTION
Can occur if histogram is resized between two calls to encodeIntoCompressedByteBuffer().