### PR TITLE
Fix serialization problem

### DIFF
--- a/src/main/java/org/HdrHistogram/AbstractHistogram.java
+++ b/src/main/java/org/HdrHistogram/AbstractHistogram.java
@@ -1572,6 +1572,7 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
         o.writeLong(startTimeStampMsec);
         o.writeLong(endTimeStampMsec);
         o.writeBoolean(autoResize);
+        o.writeInt(wordSizeInBytes);
     }
 
     private void readObject(final ObjectInputStream o)
@@ -1587,6 +1588,7 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
         final long indicatedStartTimeStampMsec = o.readLong();
         final long indicatedEndTimeStampMsec = o.readLong();
         final boolean indicatedAutoResize = o.readBoolean();
+        final int indicatedWordSizeInBytes = o.readInt();
 
         init(lowestDiscernibleValue, highestTrackableValue, numberOfSignificantValueDigits,
                 integerToDoubleValueConversionRatio, normalizingIndexOffset);
@@ -1597,6 +1599,7 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
         startTimeStampMsec = indicatedStartTimeStampMsec;
         endTimeStampMsec = indicatedEndTimeStampMsec;
         autoResize = indicatedAutoResize;
+        wordSizeInBytes = indicatedWordSizeInBytes;
     }
 
     //

--- a/src/test/java/org/HdrHistogram/HistogramTest.java
+++ b/src/test/java/org/HdrHistogram/HistogramTest.java
@@ -458,6 +458,9 @@ public class HistogramTest {
         Assert.assertEquals(
                 expectedHistogram.getTotalCount(),
                 actualHistogram.getTotalCount());
+        Assert.assertEquals(
+                expectedHistogram.getNeededByteBufferCapacity(),
+                actualHistogram.getNeededByteBufferCapacity());
         verifyMaxValue(expectedHistogram);
         verifyMaxValue(actualHistogram);
     }


### PR DESCRIPTION
* Adds test for `getNeededByteBufferCapacity()` to `HistogramTest.assertEqual()` method
* Adds `wordSizeInBytes` to serialization to fix now failing tests

Fixes issue #60