### PR TITLE
Histogram.resize fails to clear old counts when shifting to the right.

### DIFF
--- a/src/main/java/org/HdrHistogram/Histogram.java
+++ b/src/main/java/org/HdrHistogram/Histogram.java
@@ -152,6 +152,7 @@ public class Histogram extends AbstractHistogram {
             int newNormalizedZeroIndex = oldNormalizedZeroIndex + countsDelta;
             int lengthToCopy = (countsArrayLength - countsDelta) - oldNormalizedZeroIndex;
             System.arraycopy(counts, oldNormalizedZeroIndex, counts, newNormalizedZeroIndex, lengthToCopy);
+            Arrays.fill(counts, oldNormalizedZeroIndex, newNormalizedZeroIndex, 0);
         }
     }
 

--- a/src/test/java/org/HdrHistogram/HistogramTest.java
+++ b/src/test/java/org/HdrHistogram/HistogramTest.java
@@ -826,4 +826,17 @@ public class HistogramTest {
         computedMaxValue = (computedMaxValue == 0) ? 0 : histogram.highestEquivalentValue(computedMaxValue);
         Assert.assertEquals(computedMaxValue, histogram.getMaxValue());
     }
+
+    @Test
+    public void testResize() {
+      DoubleHistogram h = new DoubleHistogram(2);
+      h.setAutoResize(true);
+      h.recordValue(0);
+      h.recordValue(5);
+      h.recordValue(1);
+      h.recordValue(8);
+      h.recordValue(9);
+
+      Assert.assertEquals(9.0, h.getValueAtPercentile(100), 0.1d);
+    }
 }


### PR DESCRIPTION
Histogram.resize needs to shift its counts to the right when the normalized
zero index changes. However when doing so, it correctly calls arraycopy to
copy counts to the right, but forgets to erase counts between
`oldNormalizedZeroIndex` and `newNormalizedZeroIndex`. This makes the `counts`
array go out of sync with `totalCount`, which leads
`Histogram.getValueAtPercentile` to underestimate values.