### PR TITLE
Fixed missing spaces in multi-line messages

### DIFF
--- a/src/main/java/org/HdrHistogram/AbstractHistogram.java
+++ b/src/main/java/org/HdrHistogram/AbstractHistogram.java
@@ -1696,7 +1696,7 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
         final long maxValue = getMaxValue();
         final int relevantLength = countsArrayIndex(maxValue) + 1;
         if (buffer.capacity() < getNeededByteBufferCapacity(relevantLength)) {
-            throw new ArrayIndexOutOfBoundsException("buffer does not have capacity for" +
+            throw new ArrayIndexOutOfBoundsException("buffer does not have capacity for " +
                     getNeededByteBufferCapacity(relevantLength) + " bytes");
         }
         int initialPosition = buffer.position();
@@ -1928,10 +1928,9 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
             }
             if (count > maxAllowableCountInHistigram) {
                 throw new IllegalArgumentException(
-                        "An encoded count (" +
-                                + count +
-                                ") does not fit in the Histogram's (" +
-                                this.wordSizeInBytes + " bytes) was encountered in the source");
+                        "An encoded count (" + count +
+                        ") does not fit in the Histogram's (" +
+                        this.wordSizeInBytes + " bytes) was encountered in the source");
             }
             if (zerosCount > 0) {
                 dstIndex += zerosCount; // No need to set zeros in array. Just skip them.
@@ -1952,7 +1951,7 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
             long count = getCountAtIndex(srcIndex++);
             if (count < 0) {
                 throw new RuntimeException("Cannot encode histogram containing negative counts (" +
-                        count + " at index " + srcIndex + ", corresponding the value range [" +
+                        count + ") at index " + srcIndex + ", corresponding the value range [" +
                         lowestEquivalentValue(valueFromIndex(srcIndex)) + "," +
                         nextNonEquivalentValue(valueFromIndex(srcIndex)) + ")");
             }

--- a/src/main/java/org/HdrHistogram/DoubleHistogram.java
+++ b/src/main/java/org/HdrHistogram/DoubleHistogram.java
@@ -1429,7 +1429,7 @@ public class DoubleHistogram extends EncodableHistogram implements Serializable 
         int relevantLength = integerValuesHistogram.getLengthForNumberOfBuckets(
                 integerValuesHistogram.getBucketsNeededToCoverValue(maxValue));
         if (buffer.capacity() < getNeededByteBufferCapacity(relevantLength)) {
-            throw new ArrayIndexOutOfBoundsException("buffer does not have capacity for" +
+            throw new ArrayIndexOutOfBoundsException("buffer does not have capacity for " +
                     getNeededByteBufferCapacity(relevantLength) + " bytes");
         }
         buffer.putInt(DHIST_encodingCookie);

--- a/src/main/java/org/HdrHistogram/DoubleRecorder.java
+++ b/src/main/java/org/HdrHistogram/DoubleRecorder.java
@@ -260,7 +260,7 @@ public class DoubleRecorder {
 
         if (bad) {
             throw new IllegalArgumentException("replacement histogram must have been obtained via a previous" +
-                    "getIntervalHistogram() call from this " + this.getClass().getName() +" instance");
+                    " getIntervalHistogram() call from this " + this.getClass().getName() +" instance");
         }
     }
 }

--- a/src/main/java/org/HdrHistogram/Recorder.java
+++ b/src/main/java/org/HdrHistogram/Recorder.java
@@ -302,7 +302,7 @@ public class Recorder {
         }
         if (bad) {
             throw new IllegalArgumentException("replacement histogram must have been obtained via a previous" +
-                    "getIntervalHistogram() call from this " + this.getClass().getName() +" instance");
+                    " getIntervalHistogram() call from this " + this.getClass().getName() +" instance");
         }
     }
 }


### PR DESCRIPTION
Fixed missing spaces in multi-line messages (and a missing parenthesis as well).