### PR TITLE
Issue #79: Tool tip does not reflect accurate time scale in GoogleChart Example Plot file

### DIFF
--- a/GoogleChartsExample/plotFiles.html
+++ b/GoogleChartsExample/plotFiles.html
@@ -110,7 +110,7 @@
                         var percentile = 100.0 - (100.0/dt.getValue(row, 0));
                         return dt.getColumnLabel(j) + ': ' +
                                 percentile.toPrecision(7) +
-                                '\%\'ile = ' + dt.getValue(row, j) + ' usec'
+                                '\%\'ile = ' + dt.getValue(row, j) + ' ' + unitText
                     }
                 })(i)
             });


### PR DESCRIPTION
Fixed the tool tip issue in the example file of google charts plot example. It was a simple fix. 