### PR TITLE
Eagerly end() Inflaters to avoid a native memory leak

### DIFF
--- a/src/main/java/org/HdrHistogram/AbstractHistogram.java
+++ b/src/main/java/org/HdrHistogram/AbstractHistogram.java
@@ -2027,6 +2027,9 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
         decompressor.inflate(headerBuffer.array());
         T histogram = decodeFromByteBuffer(
                 headerBuffer, histogramClass, minBarForHighestTrackableValue, decompressor);
+
+        decompressor.end();
+
         return histogram;
     }
 


### PR DESCRIPTION
In some workloads, reading a large number of compressed histograms is required. Decompression uses `java.util.zip.Inflater`, which uses native memory. Normally it is freed by finalizers, but as shown in [JDK-6293787](https://bugs.openjdk.java.net/browse/JDK-6293787), they can be too slow, which would result in native memory being leaked.

**Steps to reproduce:**
Run the following with `-Xmx64m`:

```java
public class StressTestCompression {

    public static void main(String[] args) throws DataFormatException {
        Histogram histogram = new Histogram(1);

        while(true) {
            histogram = compressAndDecompress(histogram);
        }
    }

    private static final ByteBuffer buffer = ByteBuffer.allocate(64);

    private static Histogram compressAndDecompress(Histogram histogram) throws DataFormatException {
        buffer.position(0);

        histogram.encodeIntoCompressedByteBuffer(buffer);

        buffer.flip();

        return Histogram.decodeFromCompressedByteBuffer(buffer, histogram.highestTrackableValue);
    }

}
```

**Expected behavior:**
The process consumes slightly more than 64M of RAM.

**Actual behavior:**
The native memory usage of the process will be uncontrollably growing, reaching over half a gig in a matter of seconds, and continuing to grow.

The issue no longer reproduces if `end()` is called manually. It is already being called for compression, so only the decompression needs fixing.