### PR TITLE
Fix race condition in AbstractHistogram.updatedMaxValue

### DIFF
--- a/src/main/java/org/HdrHistogram/AbstractHistogram.java
+++ b/src/main/java/org/HdrHistogram/AbstractHistogram.java
@@ -158,8 +158,13 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
      */
     void updatedMaxValue(final long value) {
         final long internalValue = value | unitMagnitudeMask; // Max unit-equivalent value
+        long maxValue = this.maxValue;
         while (internalValue > maxValue) {
-            maxValueUpdater.compareAndSet(this, maxValue, internalValue);
+            if(maxValueUpdater.compareAndSet(this, maxValue, internalValue)) {
+                return;
+            } else {
+                maxValue = this.maxValue;
+            }
         }
     }
 


### PR DESCRIPTION
There a race condition in AbstractHistogram.updatedMaxValue(), the maxValue field is read twice, once to evaluate the while condition and again to compareAndSet, but the value may change in between. 

With an initial maxValue of 0 and thread T1 trying to write 1 and T2 trying to write 2. 
We may have:
* both threads evaluating the condition to true
* T2 reading again maxValue as 0 and CAS(0, 2) successfully
* T1 reads maxValue as 2 and CAS(2, 1) successfully too

Which results in the real maxValue being lost.
This PR fixes the issue by reading maxValue only once per loop iteration.