### PR TITLE
Fix boxed Double creation in AbstractHistogram.getStdDeviation()

### DIFF
--- a/src/main/java/org/HdrHistogram/AbstractHistogram.java
+++ b/src/main/java/org/HdrHistogram/AbstractHistogram.java
@@ -1267,7 +1267,7 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
         recordedValuesIterator.reset();
         while (recordedValuesIterator.hasNext()) {
             HistogramIterationValue iterationValue = recordedValuesIterator.next();
-            Double deviation = (medianEquivalentValue(iterationValue.getValueIteratedTo()) * 1.0) - mean;
+            double deviation = (medianEquivalentValue(iterationValue.getValueIteratedTo()) * 1.0) - mean;
             geometric_deviation_total += (deviation * deviation) * iterationValue.getCountAddedInThisIterationStep();
         }
         double std_deviation = Math.sqrt(geometric_deviation_total / getTotalCount());


### PR DESCRIPTION
This little Double appeared at the top of our allocation inducing locations during profiling.