### PR TITLE
Avoid unused allocation of inactiveHistogram in optimal usage scenario of Recorder

### DIFF
--- a/src/main/java/org/HdrHistogram/Recorder.java
+++ b/src/main/java/org/HdrHistogram/Recorder.java
@@ -84,8 +84,7 @@ public class Recorder {
                     final int numberOfSignificantValueDigits) {
         activeHistogram = new InternalAtomicHistogram(
                 instanceId, lowestDiscernibleValue, highestTrackableValue, numberOfSignificantValueDigits);
-        inactiveHistogram = new InternalAtomicHistogram(
-                instanceId, lowestDiscernibleValue, highestTrackableValue, numberOfSignificantValueDigits);
+        inactiveHistogram = null;
         activeHistogram.setStartTimeStamp(System.currentTimeMillis());
     }
 

--- a/src/main/java/org/HdrHistogram/Recorder.java
+++ b/src/main/java/org/HdrHistogram/Recorder.java
@@ -44,7 +44,7 @@ public class Recorder {
      */
     public Recorder(final int numberOfSignificantValueDigits) {
         activeHistogram = new InternalConcurrentHistogram(instanceId, numberOfSignificantValueDigits);
-        inactiveHistogram = new InternalConcurrentHistogram(instanceId, numberOfSignificantValueDigits);
+        inactiveHistogram = null;
         activeHistogram.setStartTimeStamp(System.currentTimeMillis());
     }
 


### PR DESCRIPTION
The method getIntervalHistogram(Histogram) described as more efficient for repeated use than getIntervalHistogram() and getIntervalHistogramInto(Histogram). But when client uses recorder in this way, then it pays for one unnecessary allocation for inactiveHistogram, this allocation happens each time in constructor. The allocated inactiveHistogram is never used, because first invocation of getIntervalHistogram() leads to forgetting reference to it.

You can see the best illustration of problem in the following real world examples or recorder usage:
-  [hdrhistogram-metrics-reservoir](https://bitbucket.org/marshallpierce/hdrhistogram-metrics-reservoir/src/e38dc165a01f49749fe98d452dd3bda37c22c71d/src/main/java/org/mpierce/metrics/reservoir/hdrhistogram/HdrHistogramResetOnSnapshotReservoir.java?at=master&fileviewer=file-view-default) library created by  @marshallpierce 
- [metrics-core-hdr](https://github.com/vladimir-bukhtoyarov/metrics-core-hdr/blob/1.5/src/main/java/com/github/metricscore/hdr/histogram/accumulator/UniformAccumulator.java) library created by me.

To fix problem It is enough to leave inactiveHistogram as null during construction.
