### PR TITLE
Don't try to resize in subtract() when handling a large subtrahend.

### DIFF
--- a/src/main/java/org/HdrHistogram/AbstractHistogram.java
+++ b/src/main/java/org/HdrHistogram/AbstractHistogram.java
@@ -731,7 +731,7 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
             throws ArrayIndexOutOfBoundsException, IllegalArgumentException {
         if (highestEquivalentValue(otherHistogram.getMaxValue()) >
                 highestEquivalentValue(valueFromIndex(this.countsArrayLength - 1))) {
-            throw new ArrayIndexOutOfBoundsException(
+            throw new IllegalArgumentException(
                     "The other histogram includes values that do not fit in this histogram's range.");
         }
         for (int i = 0; i < otherHistogram.countsArrayLength; i++) {

--- a/src/main/java/org/HdrHistogram/AbstractHistogram.java
+++ b/src/main/java/org/HdrHistogram/AbstractHistogram.java
@@ -729,13 +729,9 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
      */
     public void subtract(final AbstractHistogram otherHistogram)
             throws ArrayIndexOutOfBoundsException, IllegalArgumentException {
-        long highestRecordableValue = valueFromIndex(countsArrayLength - 1);
-        if (highestRecordableValue < otherHistogram.getMaxValue()) {
-            if (!isAutoResize()) {
-                throw new ArrayIndexOutOfBoundsException(
-                        "The other histogram includes values that do not fit in this histogram's range.");
-            }
-            resize(otherHistogram.getMaxValue());
+        if (highestEquivalentValue(otherHistogram.getMaxValue()) > getMaxValue()) {
+            throw new ArrayIndexOutOfBoundsException(
+                    "The other histogram includes values that do not fit in this histogram's range.");
         }
         for (int i = 0; i < otherHistogram.countsArrayLength; i++) {
             long otherCount = otherHistogram.getCountAtIndex(i);

--- a/src/main/java/org/HdrHistogram/AbstractHistogram.java
+++ b/src/main/java/org/HdrHistogram/AbstractHistogram.java
@@ -729,7 +729,8 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
      */
     public void subtract(final AbstractHistogram otherHistogram)
             throws ArrayIndexOutOfBoundsException, IllegalArgumentException {
-        if (highestEquivalentValue(otherHistogram.getMaxValue()) > getMaxValue()) {
+        if (highestEquivalentValue(otherHistogram.getMaxValue()) >
+                highestEquivalentValue(valueFromIndex(this.countsArrayLength - 1))) {
             throw new ArrayIndexOutOfBoundsException(
                     "The other histogram includes values that do not fit in this histogram's range.");
         }

--- a/src/test/java/org/HdrHistogram/HistogramTest.java
+++ b/src/test/java/org/HdrHistogram/HistogramTest.java
@@ -375,7 +375,7 @@ public class HistogramTest {
     }
 
     @Test
-    public void testSubtract() throws Exception {
+    public void testSubtractAfterAdd() {
         Histogram histogram = new Histogram(highestTrackableValue, numberOfSignificantValueDigits);
         Histogram other = new Histogram(highestTrackableValue, numberOfSignificantValueDigits);
         histogram.recordValue(testValueLevel);
@@ -394,21 +394,76 @@ public class HistogramTest {
         Assert.assertEquals(2L, histogram.getCountAtValue(testValueLevel));
         Assert.assertEquals(2L, histogram.getCountAtValue(testValueLevel * 1000));
         Assert.assertEquals(4L, histogram.getTotalCount());
+
+        verifyMaxValue(histogram);
+        verifyMaxValue(other);
+    }
+
+    @Test
+    public void testSubtractToZeroCounts() {
+        Histogram histogram = new Histogram(highestTrackableValue, numberOfSignificantValueDigits);
+        histogram.recordValue(testValueLevel);
+        histogram.recordValue(testValueLevel * 1000);
+        Assert.assertEquals(1L, histogram.getCountAtValue(testValueLevel));
+        Assert.assertEquals(1L, histogram.getCountAtValue(testValueLevel * 1000));
+        Assert.assertEquals(2L, histogram.getTotalCount());
+
         // Subtracting down to zero counts should work:
         histogram.subtract(histogram);
         Assert.assertEquals(0L, histogram.getCountAtValue(testValueLevel));
         Assert.assertEquals(0L, histogram.getCountAtValue(testValueLevel * 1000));
         Assert.assertEquals(0L, histogram.getTotalCount());
-        // But subtracting down to negative counts should not:
-        boolean thrown = false;
-        try {
-            // This should throw:
-            histogram.subtract(other);
-        } catch (IllegalArgumentException e) {
-            thrown = true;
-        }
-        Assert.assertTrue(thrown);
 
+        verifyMaxValue(histogram);
+    }
+
+    @Test
+    public void testSubtractToNegativeCountsThrows() {
+        Histogram histogram = new Histogram(highestTrackableValue, numberOfSignificantValueDigits);
+        Histogram other = new Histogram(highestTrackableValue, numberOfSignificantValueDigits);
+        histogram.recordValue(testValueLevel);
+        histogram.recordValue(testValueLevel * 1000);
+        other.recordValueWithCount(testValueLevel, 2);
+        other.recordValueWithCount(testValueLevel * 1000, 2);
+
+        try {
+            histogram.subtract(other);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // should throw
+        }
+
+        verifyMaxValue(histogram);
+        verifyMaxValue(other);
+    }
+
+    @Test
+    public void testSubtractSubtrahendValuesOutsideMinuendRangeThrows() {
+        Histogram histogram = new Histogram(highestTrackableValue, numberOfSignificantValueDigits);
+        histogram.recordValue(testValueLevel);
+        histogram.recordValue(testValueLevel * 1000);
+
+        Histogram biggerOther = new Histogram(highestTrackableValue * 2, numberOfSignificantValueDigits);
+        biggerOther.recordValue(testValueLevel);
+        biggerOther.recordValue(testValueLevel * 1000);
+        biggerOther.recordValue(highestTrackableValue * 2); // outside smaller histogram's range
+
+        try {
+            histogram.subtract(biggerOther);
+            fail();
+        } catch (ArrayIndexOutOfBoundsException e) {
+            // should throw
+        }
+
+        verifyMaxValue(histogram);
+        verifyMaxValue(biggerOther);
+    }
+
+    @Test
+    public void testSubtractSubtrahendValuesInsideMinuendRangeWorks() {
+        Histogram histogram = new Histogram(highestTrackableValue, numberOfSignificantValueDigits);
+        histogram.recordValue(testValueLevel);
+        histogram.recordValue(testValueLevel * 1000);
 
         Histogram biggerOther = new Histogram(highestTrackableValue * 2, numberOfSignificantValueDigits);
         biggerOther.recordValue(testValueLevel);
@@ -422,27 +477,15 @@ public class HistogramTest {
         Assert.assertEquals(12L, biggerOther.getTotalCount());
 
         // Subtracting the smaller histogram from the bigger one should work:
-        biggerOther.subtract(other);
+        biggerOther.subtract(histogram);
         Assert.assertEquals(3L, biggerOther.getCountAtValue(testValueLevel));
         Assert.assertEquals(3L, biggerOther.getCountAtValue(testValueLevel * 1000));
         Assert.assertEquals(4L, biggerOther.getCountAtValue(highestTrackableValue * 2)); // overflow smaller hist...
         Assert.assertEquals(10L, biggerOther.getTotalCount());
 
-        // But trying to subtract a larger histogram into a smaller one should throw an AIOOB:
-        thrown = false;
-        try {
-            // This should throw:
-            histogram.subtract(biggerOther);
-        } catch (ArrayIndexOutOfBoundsException e) {
-            thrown = true;
-        }
-        Assert.assertTrue(thrown);
-
         verifyMaxValue(histogram);
-        verifyMaxValue(other);
         verifyMaxValue(biggerOther);
     }
-
 
     @Test
     public void testSizeOfEquivalentValueRange() {

--- a/src/test/java/org/HdrHistogram/HistogramTest.java
+++ b/src/test/java/org/HdrHistogram/HistogramTest.java
@@ -451,7 +451,7 @@ public class HistogramTest {
         try {
             histogram.subtract(biggerOther);
             fail();
-        } catch (ArrayIndexOutOfBoundsException e) {
+        } catch (IllegalArgumentException e) {
             // should throw
         }
 


### PR DESCRIPTION
Also, split up testSubtract into individual cases: it was failing
after `histogram` had zero counts because of the new check for
the minuend's max value.

This is another thing I noticed while verifying the Rust port had correct logic. It seems like resizing in subtraction isn't going to do anything useful. Perhaps it is a vestige of earlier logic that yielded zero counts rather than an exception when the subtrahend had a count that exceeded the minuend's? As it is, it looks like if a subtrahend has values that aren't represented in the minuend, resizing the minuend enough to represent those values is just going to lead to an IllegalArgumentException later when the subtraction proceeds to the newly expanded parts of the array and attempts to subtract a nonzero count from the new zero entries.