### PR TITLE
Linear iterator stopping too soon

### DIFF
--- a/src/main/java/org/HdrHistogram/LinearIterator.java
+++ b/src/main/java/org/HdrHistogram/LinearIterator.java
@@ -48,11 +48,14 @@ public class LinearIterator extends AbstractHistogramIterator implements Iterato
         if (super.hasNext()) {
             return true;
         }
-        // If the next iterate will not move to the next sub bucket index (which is empty if
+        // If the next iteration will not move to the next sub bucket index (which is empty if
         // if we reached this point), then we are not yet done iterating (we want to iterate
         // until we are no longer on a value that has a count, rather than util we first reach
         // the last value that has a count. The difference is subtle but important)...
-        return (currentStepHighestValueReportingLevel + 1 < nextValueAtIndex);
+        // When this is called, we're about to begin the "next" iteration, so
+        // currentStepHighestValueReportingLevel has already been incremented, and we use it
+        // without incrementing its value.
+        return (currentStepHighestValueReportingLevel < nextValueAtIndex);
     }
 
     @Override


### PR DESCRIPTION
If I'm understanding its contract correctly, in the included test the iterator should visit the final bucket 4 times since the bucket size is 4 and the linear step is 1. However, without the change in iterator logic, it only visits 3 times, causing the test to fail because index `4103` isn't present.. 

I think this failure (and therefore the fix) is sensible when adding an extra `1` to the high end of the iterator's range, since it would have already been incremented by the previous `incrementIterationLevel()`.