### PR TITLE
FIX of message exception thrown in validateFitAsReplacementHistogram

### DIFF
--- a/src/main/java/org/HdrHistogram/SingleWriterRecorder.java
+++ b/src/main/java/org/HdrHistogram/SingleWriterRecorder.java
@@ -281,7 +281,7 @@ public class SingleWriterRecorder {
         }
 
         if (bad) {
-            throw new IllegalArgumentException("replacement histogram must have been obtained via a previous" +
+            throw new IllegalArgumentException("replacement histogram must have been obtained via a previous " +
                     "getIntervalHistogram() call from this " + this.getClass().getName() +" instance");
         }
     }


### PR DESCRIPTION
SingleWriterRecorder::validateFitAsReplacementHistogram has a spacing error in the exception message 