### PR TITLE
Fix for DOMException: Failed to read the 'cssRules' property

### DIFF
--- a/GoogleChartsExample/plotFiles.html
+++ b/GoogleChartsExample/plotFiles.html
@@ -256,8 +256,8 @@
             var css = "";
             var sheets = document.styleSheets;
             for (var i = 0; i < sheets.length; i++) {
-                var rules = sheets[i].cssRules;
-                if (rules != null) {
+                if (sheets[i].hasOwnProperty('cssRules')) {
+                    var rules = sheets[i].cssRules;
                     for (var j = 0; j < rules.length; j++) {
                         var rule = rules[j];
                         if (typeof(rule.style) != "undefined") {


### PR DESCRIPTION
In my Google Chrome browser (Version 65.0.3325.181 (Official
Build) (64-bit)) under Ubuntu 16.04.4 LTS, I get this failure when I
click on the "Export Image" button:

```
plotFiles.html:259 Uncaught DOMException: Failed to read the 'cssRules' property from 'CSSStyleSheet': Cannot access rules
    at styles (http://127.0.0.1:8080/GoogleChartsExample/plotFiles.html:259:39)
    at http://127.0.0.1:8080/GoogleChartsExample/plotFiles.html:306:36
    at inlineImages (http://127.0.0.1:8080/GoogleChartsExample/plotFiles.html:227:17)
    at out$.svgAsDataUri (http://127.0.0.1:8080/GoogleChartsExample/plotFiles.html:282:13)
    at out$.saveSvgAsPng (http://127.0.0.1:8080/GoogleChartsExample/plotFiles.html:317:18)
    at doExport (http://127.0.0.1:8080/GoogleChartsExample/plotFiles.html:180:9)
    at HTMLButtonElement.onclick (http://127.0.0.1:8080/GoogleChartsExample/plotFiles.html:364:49)
```

I haven't tested it in other browsers but this fix should improve
compatibility.