### PR TITLE
Added ValueRecorder and DoubleValueRecorder interfaces

### DIFF
--- a/src/main/java/org/HdrHistogram/AbstractHistogram.java
+++ b/src/main/java/org/HdrHistogram/AbstractHistogram.java
@@ -95,7 +95,7 @@ abstract class AbstractHistogramBase extends EncodableHistogram {
  * See package description for {@link org.HdrHistogram} for details.
  *
  */
-public abstract class AbstractHistogram extends AbstractHistogramBase implements Serializable {
+public abstract class AbstractHistogram extends AbstractHistogramBase implements ValueRecorder, Serializable {
 
     // "Hot" accessed fields (used in the the value recording code path) are bunched here, such
     // that they will have a good chance of ending up in the same cache line as the totalCounts and
@@ -422,6 +422,7 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
      * @param value The value to be recorded
      * @throws ArrayIndexOutOfBoundsException (may throw) if value is exceeds highestTrackableValue
      */
+    @Override
     public void recordValue(final long value) throws ArrayIndexOutOfBoundsException {
         recordSingleValue(value);
     }
@@ -433,6 +434,7 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
      * @param count The number of occurrences of this value to record
      * @throws ArrayIndexOutOfBoundsException (may throw) if value is exceeds highestTrackableValue
      */
+    @Override
     public void recordValueWithCount(final long value, final long count) throws ArrayIndexOutOfBoundsException {
         recordCountAtValue(count, value);
     }
@@ -458,6 +460,7 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
      *                                           than expectedIntervalBetweenValueSamples
      * @throws ArrayIndexOutOfBoundsException (may throw) if value is exceeds highestTrackableValue
      */
+    @Override
     public void recordValueWithExpectedInterval(final long value, final long expectedIntervalBetweenValueSamples)
             throws ArrayIndexOutOfBoundsException {
         recordSingleValueWithExpectedInterval(value, expectedIntervalBetweenValueSamples);
@@ -574,6 +577,7 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
     /**
      * Reset the contents and stats of this histogram
      */
+    @Override
     public void reset() {
         clearCounts();
         resetMaxValue(0);

--- a/src/main/java/org/HdrHistogram/DoubleHistogram.java
+++ b/src/main/java/org/HdrHistogram/DoubleHistogram.java
@@ -50,7 +50,7 @@ import java.util.zip.Deflater;
  * <p>
  * See package description for {@link org.HdrHistogram} for details.
  */
-public class DoubleHistogram extends EncodableHistogram implements Serializable {
+public class DoubleHistogram extends EncodableHistogram implements DoubleValueRecorder, Serializable {
     private static final double highestAllowedValueEver; // A value that will keep us from multiplying into infinity.
 
     private long configuredHighestToLowestValueRatio;
@@ -287,8 +287,9 @@ public class DoubleHistogram extends EncodableHistogram implements Serializable 
      * Record a value in the histogram
      *
      * @param value The value to be recorded
-     * @throws ArrayIndexOutOfBoundsException (may throw) if value is cannot be covered by the histogram's range
+     * @throws ArrayIndexOutOfBoundsException (may throw) if value cannot be covered by the histogram's range
      */
+    @Override
     public void recordValue(final double value) throws ArrayIndexOutOfBoundsException {
         recordSingleValue(value);
     }
@@ -298,8 +299,9 @@ public class DoubleHistogram extends EncodableHistogram implements Serializable 
      *
      * @param value The value to be recorded
      * @param count The number of occurrences of this value to record
-     * @throws ArrayIndexOutOfBoundsException (may throw) if value is cannot be covered by the histogram's range
+     * @throws ArrayIndexOutOfBoundsException (may throw) if value cannot be covered by the histogram's range
      */
+    @Override
     public void recordValueWithCount(final double value, final long count) throws ArrayIndexOutOfBoundsException {
         recordCountAtValue(count, value);
     }
@@ -323,8 +325,9 @@ public class DoubleHistogram extends EncodableHistogram implements Serializable 
      * @param expectedIntervalBetweenValueSamples If expectedIntervalBetweenValueSamples is larger than 0, add
      *                                           auto-generated value records as appropriate if value is larger
      *                                           than expectedIntervalBetweenValueSamples
-     * @throws ArrayIndexOutOfBoundsException (may throw) if value is cannot be covered by the histogram's range
+     * @throws ArrayIndexOutOfBoundsException (may throw) if value cannot be covered by the histogram's range
      */
+    @Override
     public void recordValueWithExpectedInterval(final double value, final double expectedIntervalBetweenValueSamples)
             throws ArrayIndexOutOfBoundsException {
         recordValueWithCountAndExpectedInterval(value, 1, expectedIntervalBetweenValueSamples);
@@ -573,6 +576,7 @@ public class DoubleHistogram extends EncodableHistogram implements Serializable 
     /**
      * Reset the contents and stats of this histogram
      */
+    @Override
     public void reset() {
         integerValuesHistogram.clearCounts();
     }

--- a/src/main/java/org/HdrHistogram/DoubleRecorder.java
+++ b/src/main/java/org/HdrHistogram/DoubleRecorder.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * </code></pre>
  */
 
-public class DoubleRecorder {
+public class DoubleRecorder implements DoubleValueRecorder {
     private static AtomicLong instanceIdSequencer = new AtomicLong(1);
     private final long instanceId = instanceIdSequencer.getAndIncrement();
 
@@ -83,6 +83,7 @@ public class DoubleRecorder {
      * @param value the value to record
      * @throws ArrayIndexOutOfBoundsException (may throw) if value is exceeds highestTrackableValue
      */
+    @Override
     public void recordValue(final double value) {
         long criticalValueAtEnter = recordingPhaser.writerCriticalSectionEnter();
         try {
@@ -99,6 +100,7 @@ public class DoubleRecorder {
      * @param count The number of occurrences of this value to record
      * @throws ArrayIndexOutOfBoundsException (may throw) if value is exceeds highestTrackableValue
      */
+    @Override
     public void recordValueWithCount(final double value, final long count) throws ArrayIndexOutOfBoundsException {
         long criticalValueAtEnter = recordingPhaser.writerCriticalSectionEnter();
         try {
@@ -124,6 +126,7 @@ public class DoubleRecorder {
      *                                           than expectedIntervalBetweenValueSamples
      * @throws ArrayIndexOutOfBoundsException (may throw) if value is exceeds highestTrackableValue
      */
+    @Override
     public void recordValueWithExpectedInterval(final double value, final double expectedIntervalBetweenValueSamples)
             throws ArrayIndexOutOfBoundsException {
         long criticalValueAtEnter = recordingPhaser.writerCriticalSectionEnter();
@@ -201,6 +204,7 @@ public class DoubleRecorder {
     /**
      * Reset any value counts accumulated thus far.
      */
+    @Override
     public synchronized void reset() {
         // the currently inactive histogram is reset each time we flip. So flipping twice resets both:
         performIntervalSample();

--- a/src/main/java/org/HdrHistogram/DoubleValueRecorder.java
+++ b/src/main/java/org/HdrHistogram/DoubleValueRecorder.java
@@ -1,0 +1,47 @@
+package org.HdrHistogram;
+
+public interface DoubleValueRecorder {
+
+    /**
+     * Record a value
+     *
+     * @param value The value to be recorded
+     * @throws ArrayIndexOutOfBoundsException (may throw) if value cannot be covered by the histogram's range
+     */
+    void recordValue(double value);
+
+    /**
+     * Record a value (adding to the value's current count)
+     *
+     * @param value The value to be recorded
+     * @param count The number of occurrences of this value to record
+     * @throws ArrayIndexOutOfBoundsException (may throw) if value cannot be covered by the histogram's range
+     */
+    void recordValueWithCount(double value, long count) throws ArrayIndexOutOfBoundsException;
+
+    /**
+     * Record a value.
+     * <p>
+     * To compensate for the loss of sampled values when a recorded value is larger than the expected
+     * interval between value samples, will auto-generate an additional series of decreasingly-smaller
+     * (down to the expectedIntervalBetweenValueSamples) value records.
+     * <p>
+     * Note: This is a at-recording correction method, as opposed to the post-recording correction method provided
+     * by {@link DoubleHistogram#copyCorrectedForCoordinatedOmission(double)}.
+     * The two methods are mutually exclusive, and only one of the two should be be used on a given data set to correct
+     * for the same coordinated omission issue.
+     *
+     * @param value                               The value to record
+     * @param expectedIntervalBetweenValueSamples If expectedIntervalBetweenValueSamples is larger than 0, add
+     *                                            auto-generated value records as appropriate if value is larger
+     *                                            than expectedIntervalBetweenValueSamples
+     * @throws ArrayIndexOutOfBoundsException (may throw) if value cannot be covered by the histogram's range
+     */
+    void recordValueWithExpectedInterval(double value, double expectedIntervalBetweenValueSamples)
+            throws ArrayIndexOutOfBoundsException;
+
+    /**
+     * Reset the contents and collected stats
+     */
+    void reset();
+}

--- a/src/main/java/org/HdrHistogram/Recorder.java
+++ b/src/main/java/org/HdrHistogram/Recorder.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  */
 
-public class Recorder {
+public class Recorder implements ValueRecorder {
     private static AtomicLong instanceIdSequencer = new AtomicLong(1);
     private final long instanceId = instanceIdSequencer.getAndIncrement();
 
@@ -107,6 +107,7 @@ public class Recorder {
      * @param value the value to record
      * @throws ArrayIndexOutOfBoundsException (may throw) if value is exceeds highestTrackableValue
      */
+    @Override
     public void recordValue(final long value) throws ArrayIndexOutOfBoundsException {
         long criticalValueAtEnter = recordingPhaser.writerCriticalSectionEnter();
         try {
@@ -123,6 +124,7 @@ public class Recorder {
      * @param count The number of occurrences of this value to record
      * @throws ArrayIndexOutOfBoundsException (may throw) if value is exceeds highestTrackableValue
      */
+    @Override
     public void recordValueWithCount(final long value, final long count) throws ArrayIndexOutOfBoundsException {
         long criticalValueAtEnter = recordingPhaser.writerCriticalSectionEnter();
         try {
@@ -148,6 +150,7 @@ public class Recorder {
      *                                           than expectedIntervalBetweenValueSamples
      * @throws ArrayIndexOutOfBoundsException (may throw) if value is exceeds highestTrackableValue
      */
+    @Override
     public void recordValueWithExpectedInterval(final long value, final long expectedIntervalBetweenValueSamples)
             throws ArrayIndexOutOfBoundsException {
         long criticalValueAtEnter = recordingPhaser.writerCriticalSectionEnter();
@@ -225,6 +228,7 @@ public class Recorder {
     /**
      * Reset any value counts accumulated thus far.
      */
+    @Override
     public synchronized void reset() {
         // the currently inactive histogram is reset each time we flip. So flipping twice resets both:
         performIntervalSample();

--- a/src/main/java/org/HdrHistogram/SingleWriterRecorder.java
+++ b/src/main/java/org/HdrHistogram/SingleWriterRecorder.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * </code></pre>
  */
 
-public class SingleWriterRecorder {
+public class SingleWriterRecorder implements ValueRecorder {
     private static AtomicLong instanceIdSequencer = new AtomicLong(1);
     private final long instanceId = instanceIdSequencer.getAndIncrement();
 
@@ -106,6 +106,7 @@ public class SingleWriterRecorder {
      * @param value the value to record
      * @throws ArrayIndexOutOfBoundsException (may throw) if value is exceeds highestTrackableValue
      */
+    @Override
     public void recordValue(final long value) {
         long criticalValueAtEnter = recordingPhaser.writerCriticalSectionEnter();
         try {
@@ -122,6 +123,7 @@ public class SingleWriterRecorder {
      * @param count The number of occurrences of this value to record
      * @throws ArrayIndexOutOfBoundsException (may throw) if value is exceeds highestTrackableValue
      */
+    @Override
     public void recordValueWithCount(final long value, final long count) throws ArrayIndexOutOfBoundsException {
         long criticalValueAtEnter = recordingPhaser.writerCriticalSectionEnter();
         try {
@@ -147,6 +149,7 @@ public class SingleWriterRecorder {
      *                                           than expectedIntervalBetweenValueSamples
      * @throws ArrayIndexOutOfBoundsException (may throw) if value is exceeds highestTrackableValue
      */
+    @Override
     public void recordValueWithExpectedInterval(final long value, final long expectedIntervalBetweenValueSamples)
             throws ArrayIndexOutOfBoundsException {
         long criticalValueAtEnter = recordingPhaser.writerCriticalSectionEnter();
@@ -224,6 +227,7 @@ public class SingleWriterRecorder {
     /**
      * Reset any value counts accumulated thus far.
      */
+    @Override
     public synchronized void reset() {
         // the currently inactive histogram is reset each time we flip. So flipping twice resets both:
         performIntervalSample();

--- a/src/main/java/org/HdrHistogram/ValueRecorder.java
+++ b/src/main/java/org/HdrHistogram/ValueRecorder.java
@@ -1,0 +1,47 @@
+package org.HdrHistogram;
+
+public interface ValueRecorder {
+
+    /**
+     * Record a value
+     *
+     * @param value The value to be recorded
+     * @throws ArrayIndexOutOfBoundsException (may throw) if value cannot be covered by the histogram's range
+     */
+    void recordValue(long value);
+
+    /**
+     * Record a value (adding to the value's current count)
+     *
+     * @param value The value to be recorded
+     * @param count The number of occurrences of this value to record
+     * @throws ArrayIndexOutOfBoundsException (may throw) if value cannot be covered by the histogram's range
+     */
+    void recordValueWithCount(long value, long count) throws ArrayIndexOutOfBoundsException;
+
+    /**
+     * Record a value.
+     * <p>
+     * To compensate for the loss of sampled values when a recorded value is larger than the expected
+     * interval between value samples, will auto-generate an additional series of decreasingly-smaller
+     * (down to the expectedIntervalBetweenValueSamples) value records.
+     * <p>
+     * Note: This is a at-recording correction method, as opposed to the post-recording correction method provided
+     * by {@link AbstractHistogram#copyCorrectedForCoordinatedOmission(long)}.
+     * The two methods are mutually exclusive, and only one of the two should be be used on a given data set to correct
+     * for the same coordinated omission issue.
+     *
+     * @param value                               The value to record
+     * @param expectedIntervalBetweenValueSamples If expectedIntervalBetweenValueSamples is larger than 0, add
+     *                                            auto-generated value records as appropriate if value is larger
+     *                                            than expectedIntervalBetweenValueSamples
+     * @throws ArrayIndexOutOfBoundsException (may throw) if value cannot be covered by the histogram's range
+     */
+    void recordValueWithExpectedInterval(long value, long expectedIntervalBetweenValueSamples)
+            throws ArrayIndexOutOfBoundsException;
+
+    /**
+     * Reset the contents and collected stats
+     */
+    void reset();
+}


### PR DESCRIPTION
Recorders and Histograms classes are sharing a common recording API
without any contract that allow a caller to use both with a
polymorphic declaration.