### PR TITLE
Fix exception when comparing histograms with different bucket counts

### DIFF
--- a/src/main/java/org/HdrHistogram/AbstractHistogram.java
+++ b/src/main/java/org/HdrHistogram/AbstractHistogram.java
@@ -1012,9 +1012,25 @@ public abstract class AbstractHistogram extends AbstractHistogramBase implements
         if (getMinNonZeroValue() != that.getMinNonZeroValue()) {
             return false;
         }
-        for (int i = 0; i < countsArrayLength; i++) {
-            if (getCountAtIndex(i) != that.getCountAtIndex(i)) {
-                return false;
+        // 2 histograms may be equal but have different underlying array sizes. This can happen for instance due to
+        // resizing.
+        if (countsArrayLength == that.countsArrayLength) {
+            for (int i = 0; i < countsArrayLength; i++) {
+                if (getCountAtIndex(i) != that.getCountAtIndex(i)) {
+                    return false;
+                }
+            }
+        }
+        else
+        {
+            // Comparing the values is valid here because we have already confirmed the histograms have the same total
+            // count. It would not be correct otherwise.
+            for (HistogramIterationValue value : this.recordedValues()) {
+                long countAtValueIteratedTo = value.getCountAtValueIteratedTo();
+                long valueIteratedTo = value.getValueIteratedTo();
+                if (that.getCountAtValue(valueIteratedTo) != countAtValueIteratedTo) {
+                    return false;
+                }
             }
         }
         return true;

--- a/src/test/java/org/HdrHistogram/HistogramAutosizingTest.java
+++ b/src/test/java/org/HdrHistogram/HistogramAutosizingTest.java
@@ -29,6 +29,23 @@ public class HistogramAutosizingTest {
     }
 
     @Test
+    public void testHistogramEqualsAfterResizing() throws Exception {
+        Histogram histogram = new Histogram(3);
+        histogram.recordValue((1L << 62) - 1);
+        Assert.assertEquals(52, histogram.bucketCount);
+        Assert.assertEquals(54272, histogram.countsArrayLength);
+        histogram.recordValue(Long.MAX_VALUE);
+        Assert.assertEquals(53, histogram.bucketCount);
+        Assert.assertEquals(55296, histogram.countsArrayLength);
+        histogram.reset();
+        histogram.recordValue((1L << 62) - 1);
+        
+        Histogram histogram1 = new Histogram(3);
+        histogram1.recordValue((1L << 62) - 1);
+        Assert.assertEquals(histogram, histogram1);
+    }
+
+    @Test
     public void testDoubleHistogramAutoSizingEdges() throws Exception {
         DoubleHistogram histogram = new DoubleHistogram(3);
         histogram.recordValue(1);


### PR DESCRIPTION
Fix #144 