### PR TITLE
Fix top level shifting while populating context

### DIFF
--- a/src/main/java/org/HdrHistogram/packedarray/AbstractPackedArrayContext.java
+++ b/src/main/java/org/HdrHistogram/packedarray/AbstractPackedArrayContext.java
@@ -698,7 +698,7 @@ abstract class AbstractPackedArrayContext implements Serializable {
             int otherEntryIndex = other.getAtShortIndex(SET_0_START_INDEX + i);
             if (otherEntryIndex == 0) continue; // No tree to duplicate
             int entryIndexPointer = SET_0_START_INDEX + i;
-            for (i = getTopLevelShift(); i > other.getTopLevelShift(); i -= 4) {
+            for (int j = getTopLevelShift(); j > other.getTopLevelShift(); j -= 4) {
                 // for each inserted level:
 
                 // Allocate entry in other:


### PR DESCRIPTION
Happy new year @giltene !
This PR change a little bit the behaviour of method populateEquivalentEntriesWithZerosFromOther.
Unless I am wrong there was an issue with the loop going from one level to another.
I have some other remarks about this method but I will try to reach you first on gitter before sending a PR.
