### PR TITLE
Handle IndexOutOfBoundsException properly on Java 8

### DIFF
--- a/src/main/java/org/HdrHistogram/DoubleHistogram.java
+++ b/src/main/java/org/HdrHistogram/DoubleHistogram.java
@@ -339,7 +339,7 @@ public class DoubleHistogram extends EncodableHistogram implements DoubleValueRe
             try {
                 integerValuesHistogram.recordConvertedDoubleValueWithCount(value, count);
                 return;
-            } catch (ArrayIndexOutOfBoundsException ex) {
+            } catch (IndexOutOfBoundsException ex) {
                 // A race that would pass the auto-range check above and would still take an AIOOB
                 // can only occur due to a value that would have been valid becoming invalid due
                 // to a concurrent adjustment operation. Such adjustment operations can happen no
@@ -366,7 +366,7 @@ public class DoubleHistogram extends EncodableHistogram implements DoubleValueRe
             try {
                 integerValuesHistogram.recordConvertedDoubleValue(value);
                 return;
-            } catch (ArrayIndexOutOfBoundsException ex) {
+            } catch (IndexOutOfBoundsException ex) {
                 // A race that would pass the auto-range check above and would still take an AIOOB
                 // can only occur due to a value that would have been valid becoming invalid due
                 // to a concurrent adjustment operation. Such adjustment operations can happen no


### PR DESCRIPTION
On JDK 11 it throws ArrayIndexOutOfBoundsException whereas on JDK 8 it's IndexOutOfBoundsException resulting in this exception not being caught. The fix is to catch IndexOutOfBoundsException instead of ArrayIndexOutOfBoundsException, so it will work for both JDK 8 and JDK 11

Resolves: #179