### PR TITLE
Adding API to abstract histogram snapshot sources

### DIFF
--- a/src/main/java/org/HdrHistogram/DoubleRecorder.java
+++ b/src/main/java/org/HdrHistogram/DoubleRecorder.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * </code></pre>
  */
 
-public class DoubleRecorder implements DoubleValueRecorder {
+public class DoubleRecorder implements DoubleValueRecorder, IntervalHistogramProvider<DoubleHistogram> {
     private static AtomicLong instanceIdSequencer = new AtomicLong(1);
     private final long instanceId = instanceIdSequencer.getAndIncrement();
 
@@ -159,77 +159,17 @@ public class DoubleRecorder implements DoubleValueRecorder {
         }
     }
 
-    /**
-     * Get a new instance of an interval histogram, which will include a stable, consistent view of all value
-     * counts accumulated since the last interval histogram was taken.
-     * <p>
-     * Calling {@code getIntervalHistogram()} will reset
-     * the value counts, and start accumulating value counts for the next interval.
-     *
-     * @return a histogram containing the value counts accumulated since the last interval histogram was taken.
-     */
+    @Override
     public synchronized DoubleHistogram getIntervalHistogram() {
         return getIntervalHistogram(null);
     }
 
-    /**
-     * Get an interval histogram, which will include a stable, consistent view of all value counts
-     * accumulated since the last interval histogram was taken.
-     * <p>
-     * {@code getIntervalHistogram(histogramToRecycle)}
-     * accepts a previously returned interval histogram that can be recycled internally to avoid allocation
-     * and content copying operations, and is therefore significantly more efficient for repeated use than
-     * {@link DoubleRecorder#getIntervalHistogram()} and
-     * {@link DoubleRecorder#getIntervalHistogramInto getIntervalHistogramInto()}. The provided
-     * {@code histogramToRecycle} must
-     * be either be null or an interval histogram returned by a previous call to
-     * {@code getIntervalHistogram(histogramToRecycle)} or {@link DoubleRecorder#getIntervalHistogram()}.
-     * <p>
-     * NOTE: The caller is responsible for not recycling the same returned interval histogram more than once. If
-     * the same interval histogram instance is recycled more than once, behavior is undefined.
-     * <p>
-     * Calling {@code getIntervalHistogram(histogramToRecycle)} will reset the value counts, and start
-     * accumulating value counts for the next interval
-     *
-     * @param histogramToRecycle a previously returned interval histogram (from this instance of
-     *                           {@link DoubleRecorder}) that may be recycled to avoid allocation and
-     *                           copy operations.
-     * @return a histogram containing the value counts accumulated since the last interval histogram was taken.
-     */
+    @Override
     public synchronized DoubleHistogram getIntervalHistogram(DoubleHistogram histogramToRecycle) {
         return getIntervalHistogram(histogramToRecycle, true);
     }
 
-    /**
-     * Get an interval histogram, which will include a stable, consistent view of all value counts
-     * accumulated since the last interval histogram was taken.
-     * <p>
-     * {@link DoubleRecorder#getIntervalHistogram(DoubleHistogram histogramToRecycle)
-     * getIntervalHistogram(histogramToRecycle)}
-     * accepts a previously returned interval histogram that can be recycled internally to avoid allocation
-     * and content copying operations, and is therefore significantly more efficient for repeated use than
-     * {@link DoubleRecorder#getIntervalHistogram()} and
-     * {@link DoubleRecorder#getIntervalHistogramInto getIntervalHistogramInto()}. The provided
-     * {@code histogramToRecycle} must
-     * be either be null or an interval histogram returned by a previous call to
-     * {@link DoubleRecorder#getIntervalHistogram(DoubleHistogram histogramToRecycle)
-     * getIntervalHistogram(histogramToRecycle)} or
-     * {@link DoubleRecorder#getIntervalHistogram()}.
-     * <p>
-     * NOTE: The caller is responsible for not recycling the same returned interval histogram more than once. If
-     * the same interval histogram instance is recycled more than once, behavior is undefined.
-     * <p>
-     * Calling {@link DoubleRecorder#getIntervalHistogram(DoubleHistogram histogramToRecycle)
-     * getIntervalHistogram(histogramToRecycle)} will reset the value counts, and start accumulating value
-     * counts for the next interval
-     *
-     * @param histogramToRecycle a previously returned interval histogram that may be recycled to avoid allocation and
-     *                           copy operations.
-     * @param enforceContainingInstance if true, will only allow recycling of histograms previously returned from this
-     *                                 instance of {@link DoubleRecorder}. If false, will allow recycling histograms
-     *                                 previously returned by other instances of {@link DoubleRecorder}.
-     * @return a histogram containing the value counts accumulated since the last interval histogram was taken.
-     */
+    @Override
     public synchronized DoubleHistogram getIntervalHistogram(DoubleHistogram histogramToRecycle,
                                                              boolean enforceContainingInstance) {
         // Verify that replacement histogram can validly be used as an inactive histogram replacement:
@@ -241,15 +181,7 @@ public class DoubleRecorder implements DoubleValueRecorder {
         return sampledHistogram;
     }
 
-    /**
-     * Place a copy of the value counts accumulated since accumulated (since the last interval histogram
-     * was taken) into {@code targetHistogram}.
-     *
-     * Calling {@code getIntervalHistogramInto(targetHistogram)} will reset
-     * the value counts, and start accumulating value counts for the next interval.
-     *
-     * @param targetHistogram the histogram into which the interval histogram's data should be copied
-     */
+    @Override
     public synchronized void getIntervalHistogramInto(DoubleHistogram targetHistogram) {
         performIntervalSample();
         inactiveHistogram.copyInto(targetHistogram);

--- a/src/main/java/org/HdrHistogram/IntervalHistogramProvider.java
+++ b/src/main/java/org/HdrHistogram/IntervalHistogramProvider.java
@@ -1,0 +1,86 @@
+package org.HdrHistogram;
+
+public interface IntervalHistogramProvider<T extends EncodableHistogram> {
+
+   /**
+    * Get a new instance of an interval histogram, which will include a stable, consistent view of all value
+    * counts accumulated since the last interval histogram was taken.
+    * <p>
+    * Calling this will reset the value counts, and start accumulating value counts for the next interval.
+    *
+    * @return a histogram containing the value counts accumulated since the last interval histogram was taken.
+    */
+   T getIntervalHistogram();
+
+   /**
+    * Get an interval histogram, which will include a stable, consistent view of all value counts
+    * accumulated since the last interval histogram was taken.
+    * <p>
+    * {@link #getIntervalHistogram(EncodableHistogram histogramToRecycle)
+    * getIntervalHistogram(histogramToRecycle)}
+    * accepts a previously returned interval histogram that can be recycled internally to avoid allocation
+    * and content copying operations, and is therefore significantly more efficient for repeated use than
+    * {@link #getIntervalHistogram()} and
+    * {@link #getIntervalHistogramInto getIntervalHistogramInto()}. The provided
+    * {@code histogramToRecycle} must
+    * be either be null or an interval histogram returned by a previous call to
+    * {@link #getIntervalHistogram(EncodableHistogram histogramToRecycle)
+    * getIntervalHistogram(histogramToRecycle)} or
+    * {@link #getIntervalHistogram()}.
+    * <p>
+    * NOTE: The caller is responsible for not recycling the same returned interval histogram more than once. If
+    * the same interval histogram instance is recycled more than once, behavior is undefined.
+    * <p>
+    * Calling {@link #getIntervalHistogram(EncodableHistogram histogramToRecycle)
+    * getIntervalHistogram(histogramToRecycle)} will reset the value counts, and start accumulating value
+    * counts for the next interval
+    *
+    * @param histogramToRecycle a previously returned interval histogram that may be recycled to avoid allocation and
+    *                           copy operations.
+    * @return a histogram containing the value counts accumulated since the last interval histogram was taken.
+    */
+   T getIntervalHistogram(T histogramToRecycle);
+
+   /**
+    * Get an interval histogram, which will include a stable, consistent view of all value counts
+    * accumulated since the last interval histogram was taken.
+    * <p>
+    * {@link #getIntervalHistogram(EncodableHistogram histogramToRecycle)
+    * getIntervalHistogram(histogramToRecycle)}
+    * accepts a previously returned interval histogram that can be recycled internally to avoid allocation
+    * and content copying operations, and is therefore significantly more efficient for repeated use than
+    * {@link #getIntervalHistogram()} and
+    * {@link #getIntervalHistogramInto getIntervalHistogramInto()}. The provided
+    * {@code histogramToRecycle} must
+    * be either be null or an interval histogram returned by a previous call to
+    * {@link #getIntervalHistogram(EncodableHistogram histogramToRecycle)
+    * getIntervalHistogram(histogramToRecycle)} or
+    * {@link #getIntervalHistogram()}.
+    * <p>
+    * NOTE: The caller is responsible for not recycling the same returned interval histogram more than once. If
+    * the same interval histogram instance is recycled more than once, behavior is undefined.
+    * <p>
+    * Calling {@link #getIntervalHistogram(EncodableHistogram histogramToRecycle)
+    * getIntervalHistogram(histogramToRecycle)} will reset the value counts, and start accumulating value
+    * counts for the next interval
+    *
+    * @param histogramToRecycle        a previously returned interval histogram that may be recycled to avoid allocation and
+    *                                  copy operations.
+    * @param enforceContainingInstance if true, will only allow recycling of histograms previously returned from this
+    *                                  instance of {@link IntervalHistogramProvider}. If false, will allow recycling histograms
+    *                                  previously returned by other instances of {@link IntervalHistogramProvider}.
+    * @return a histogram containing the value counts accumulated since the last interval histogram was taken.
+    */
+   T getIntervalHistogram(T histogramToRecycle, boolean enforceContainingInstance);
+
+   /**
+    * Place a copy of the value counts accumulated since accumulated (since the last interval histogram
+    * was taken) into {@code targetHistogram}.
+    * <p>
+    * Calling {@link #getIntervalHistogramInto getIntervalHistogramInto()} will reset
+    * the value counts, and start accumulating value counts for the next interval.
+    *
+    * @param targetHistogram the histogram into which the interval histogram's data should be copied
+    */
+   void getIntervalHistogramInto(T targetHistogram);
+}

--- a/src/main/java/org/HdrHistogram/SingleWriterDoubleRecorder.java
+++ b/src/main/java/org/HdrHistogram/SingleWriterDoubleRecorder.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * </code></pre>
  */
 
-public class SingleWriterDoubleRecorder implements DoubleValueRecorder {
+public class SingleWriterDoubleRecorder implements DoubleValueRecorder, IntervalHistogramProvider<DoubleHistogram> {
     private static AtomicLong instanceIdSequencer = new AtomicLong(1);
     private final long instanceId = instanceIdSequencer.getAndIncrement();
 
@@ -156,80 +156,17 @@ public class SingleWriterDoubleRecorder implements DoubleValueRecorder {
         }
     }
 
-    /**
-     * Get a new instance of an interval histogram, which will include a stable, consistent view of all value
-     * counts accumulated since the last interval histogram was taken.
-     * <p>
-     * Calling {@code getIntervalHistogram()} will reset
-     * the value counts, and start accumulating value counts for the next interval.
-     *
-     * @return a histogram containing the value counts accumulated since the last interval histogram was taken.
-     */
+    @Override
     public synchronized DoubleHistogram getIntervalHistogram() {
         return getIntervalHistogram(null);
     }
 
-    /**
-     * Get an interval histogram, which will include a stable, consistent view of all value counts
-     * accumulated since the last interval histogram was taken.
-     * <p>
-     * {@code getIntervalHistogram(histogramToRecycle)}
-     * accepts a previously returned interval histogram that can be recycled internally to avoid allocation
-     * and content copying operations, and is therefore significantly more efficient for repeated use than
-     * {@link SingleWriterDoubleRecorder#getIntervalHistogram()} and
-     * {@link SingleWriterDoubleRecorder#getIntervalHistogramInto getIntervalHistogramInto()}. The
-     * provided {@code histogramToRecycle} must
-     * be either be null or an interval histogram returned by a previous call to
-     * {@code getIntervalHistogram(histogramToRecycle)} or
-     * {@link SingleWriterDoubleRecorder#getIntervalHistogram()}.
-     * <p>
-     * NOTE: The caller is responsible for not recycling the same returned interval histogram more than once. If
-     * the same interval histogram instance is recycled more than once, behavior is undefined.
-     * <p>
-     * Calling
-     * {@code getIntervalHistogram(histogramToRecycle)} will reset the value counts, and start accumulating value
-     * counts for the next interval
-     *
-     * @param histogramToRecycle a previously returned interval histogram (from this instance of
-     *                           {@link SingleWriterDoubleRecorder}) that may be recycled to avoid allocation and
-     *                           copy operations.
-     * @return a histogram containing the value counts accumulated since the last interval histogram was taken.
-     */
+    @Override
     public synchronized DoubleHistogram getIntervalHistogram(DoubleHistogram histogramToRecycle) {
         return getIntervalHistogram(histogramToRecycle, true);
     }
 
-    /**
-     * Get an interval histogram, which will include a stable, consistent view of all value counts
-     * accumulated since the last interval histogram was taken.
-     * <p>
-     * {@link SingleWriterDoubleRecorder#getIntervalHistogram(DoubleHistogram histogramToRecycle)
-     * getIntervalHistogram(histogramToRecycle)}
-     * accepts a previously returned interval histogram that can be recycled internally to avoid allocation
-     * and content copying operations, and is therefore significantly more efficient for repeated use than
-     * {@link SingleWriterDoubleRecorder#getIntervalHistogram()} and
-     * {@link SingleWriterDoubleRecorder#getIntervalHistogramInto getIntervalHistogramInto()}. The
-     * provided {@code histogramToRecycle} must
-     * be either be null or an interval histogram returned by a previous call to
-     * {@link SingleWriterDoubleRecorder#getIntervalHistogram(DoubleHistogram histogramToRecycle)
-     * getIntervalHistogram(histogramToRecycle)} or
-     * {@link SingleWriterDoubleRecorder#getIntervalHistogram()}.
-     * <p>
-     * NOTE: The caller is responsible for not recycling the same returned interval histogram more than once. If
-     * the same interval histogram instance is recycled more than once, behavior is undefined.
-     * <p>
-     * Calling
-     * {@link SingleWriterDoubleRecorder#getIntervalHistogram(DoubleHistogram histogramToRecycle)
-     * getIntervalHistogram(histogramToRecycle)} will reset the value counts, and start accumulating value
-     * counts for the next interval
-     *
-     * @param histogramToRecycle a previously returned interval histogram that may be recycled to avoid allocation and
-     *                           copy operations.
-     * @param enforceContainingInstance if true, will only allow recycling of histograms previously returned from this
-     *                                 instance of {@link SingleWriterDoubleRecorder}. If false, will allow recycling histograms
-     *                                 previously returned by other instances of {@link SingleWriterDoubleRecorder}.
-     * @return a histogram containing the value counts accumulated since the last interval histogram was taken.
-     */
+    @Override
     public synchronized DoubleHistogram getIntervalHistogram(DoubleHistogram histogramToRecycle,
                                                              boolean enforceContainingInstance) {
         // Verify that replacement histogram can validly be used as an inactive histogram replacement:
@@ -241,15 +178,7 @@ public class SingleWriterDoubleRecorder implements DoubleValueRecorder {
         return sampledHistogram;
     }
 
-    /**
-     * Place a copy of the value counts accumulated since accumulated (since the last interval histogram
-     * was taken) into {@code targetHistogram}.
-     *
-     * Calling {@code getIntervalHistogramInto(targetHistogram)} will
-     * reset the value counts, and start accumulating value counts for the next interval.
-     *
-     * @param targetHistogram the histogram into which the interval histogram's data should be copied
-     */
+    @Override
     public synchronized void getIntervalHistogramInto(DoubleHistogram targetHistogram) {
         performIntervalSample();
         inactiveHistogram.copyInto(targetHistogram);

--- a/src/main/java/org/HdrHistogram/SingleWriterRecorder.java
+++ b/src/main/java/org/HdrHistogram/SingleWriterRecorder.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * </code></pre>
  */
 
-public class SingleWriterRecorder implements ValueRecorder {
+public class SingleWriterRecorder implements ValueRecorder, IntervalHistogramProvider<Histogram> {
     private static AtomicLong instanceIdSequencer = new AtomicLong(1);
     private final long instanceId = instanceIdSequencer.getAndIncrement();
 
@@ -184,78 +184,17 @@ public class SingleWriterRecorder implements ValueRecorder {
         }
     }
 
-    /**
-     * Get a new instance of an interval histogram, which will include a stable, consistent view of all value
-     * counts accumulated since the last interval histogram was taken.
-     * <p>
-     * Calling {@code getIntervalHistogram()} will reset
-     * the value counts, and start accumulating value counts for the next interval.
-     *
-     * @return a histogram containing the value counts accumulated since the last interval histogram was taken.
-     */
+    @Override
     public synchronized Histogram getIntervalHistogram() {
         return getIntervalHistogram(null);
     }
 
-    /**
-     * Get an interval histogram, which will include a stable, consistent view of all value counts
-     * accumulated since the last interval histogram was taken.
-     * <p>
-     * {@code getIntervalHistogram(histogramToRecycle)}
-     * accepts a previously returned interval histogram that can be recycled internally to avoid allocation
-     * and content copying operations, and is therefore significantly more efficient for repeated use than
-     * {@link SingleWriterRecorder#getIntervalHistogram()} and
-     * {@link SingleWriterRecorder#getIntervalHistogramInto getIntervalHistogramInto()}. The provided
-     * {@code histogramToRecycle} must
-     * be either be null or an interval histogram returned by a previous call to
-     * {@code getIntervalHistogram(histogramToRecycle)} or
-     * {@link SingleWriterRecorder#getIntervalHistogram()}.
-     * <p>
-     * NOTE: The caller is responsible for not recycling the same returned interval histogram more than once. If
-     * the same interval histogram instance is recycled more than once, behavior is undefined.
-     * <p>
-     * Calling {@code getIntervalHistogram(histogramToRecycle)} will reset the value counts, and start
-     * accumulating value counts for the next interval
-     *
-     * @param histogramToRecycle a previously returned interval histogram (from this instance of
-     *                           {@link SingleWriterRecorder}) that may be recycled to avoid allocation and
-     *                           copy operations.
-     * @return a histogram containing the value counts accumulated since the last interval histogram was taken.
-     */
+    @Override
     public synchronized Histogram getIntervalHistogram(Histogram histogramToRecycle) {
         return getIntervalHistogram(histogramToRecycle, true);
     }
 
-    /**
-     * Get an interval histogram, which will include a stable, consistent view of all value counts
-     * accumulated since the last interval histogram was taken.
-     * <p>
-     * {@link SingleWriterRecorder#getIntervalHistogram(Histogram histogramToRecycle)
-     * getIntervalHistogram(histogramToRecycle)}
-     * accepts a previously returned interval histogram that can be recycled internally to avoid allocation
-     * and content copying operations, and is therefore significantly more efficient for repeated use than
-     * {@link SingleWriterRecorder#getIntervalHistogram()} and
-     * {@link SingleWriterRecorder#getIntervalHistogramInto getIntervalHistogramInto()}. The provided
-     * {@code histogramToRecycle} must
-     * be either be null or an interval histogram returned by a previous call to
-     * {@link SingleWriterRecorder#getIntervalHistogram(Histogram histogramToRecycle)
-     * getIntervalHistogram(histogramToRecycle)} or
-     * {@link SingleWriterRecorder#getIntervalHistogram()}.
-     * <p>
-     * NOTE: The caller is responsible for not recycling the same returned interval histogram more than once. If
-     * the same interval histogram instance is recycled more than once, behavior is undefined.
-     * <p>
-     * Calling {@link SingleWriterRecorder#getIntervalHistogram(Histogram histogramToRecycle)
-     * getIntervalHistogram(histogramToRecycle)} will reset the value counts, and start accumulating value
-     * counts for the next interval
-     *
-     * @param histogramToRecycle a previously returned interval histogram that may be recycled to avoid allocation and
-     *                           copy operations.
-     * @param enforceContainingInstance if true, will only allow recycling of histograms previously returned from this
-     *                                 instance of {@link SingleWriterRecorder}. If false, will allow recycling histograms
-     *                                 previously returned by other instances of {@link SingleWriterRecorder}.
-     * @return a histogram containing the value counts accumulated since the last interval histogram was taken.
-     */
+    @Override
     public synchronized Histogram getIntervalHistogram(Histogram histogramToRecycle,
                                                        boolean enforceContainingInstance) {
         // Verify that replacement histogram can validly be used as an inactive histogram replacement:
@@ -267,15 +206,7 @@ public class SingleWriterRecorder implements ValueRecorder {
         return sampledHistogram;
     }
 
-    /**
-     * Place a copy of the value counts accumulated since accumulated (since the last interval histogram
-     * was taken) into {@code targetHistogram}.
-     *
-     * Calling {@code getIntervalHistogramInto(targetHistogram)} will reset
-     * the value counts, and start accumulating value counts for the next interval.
-     *
-     * @param targetHistogram the histogram into which the interval histogram's data should be copied
-     */
+    @Override
     public synchronized void getIntervalHistogramInto(Histogram targetHistogram) {
         performIntervalSample();
         inactiveHistogram.copyInto(targetHistogram);


### PR DESCRIPTION
This is creating a common API for histogram snapshot sources.

I've a couple of reporter threads that are casting `Recorder` and `SingleWriterRecorder` to snapshot histograms :(
eg
```java 
            if (recorder instanceof Recorder) {
               reportHistogram = ((Recorder) recorder).getIntervalHistogram(reportHistogram);
            } else if (recorder instanceof SingleWriterRecorder) {
               reportHistogram = ((SingleWriterRecorder) recorder).getIntervalHistogram(reportHistogram);
            }
```
This change will just make the user code more concise.