### PR TITLE
add license file to jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,15 @@
     </distributionManagement>
 
     <build>
+        <resources>
+            <resource>
+                <directory>.</directory>
+                <targetPath>META-INF</targetPath>
+                <includes>
+                    <include>LICENSE.txt</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
For a customer project an OpenSource report has to be generated. Therefore a scanner was created to extract the copyright and licence information from our dependencies. This scanner can extract all informaton from the Jar File. Therefore it would be great to have the license information included in the Jar File.