### PR TITLE
Add module-info via moditect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,10 +92,36 @@
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                            <Automatic-Module-Name>org.HdrHistogram</Automatic-Module-Name>
                         </manifest>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.Final</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <overwriteExistingFiles>true</overwriteExistingFiles>
+                            <module>
+                                <moduleInfo>
+                                    <name>org.HdrHistogram</name>
+                                    <exports>
+                                        org.HdrHistogram;
+                                        org.HdrHistogram.packedarray;
+                                    </exports>
+                                </moduleInfo>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This adds an explicit module info using the moditect maven plugin. 

Reference for how I ended up here

https://github.com/micrometer-metrics/micrometer/issues/4990