### PR TITLE
HdrHistogram explicit Java module.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,23 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
+                <groupId>io.github.dmlloyd.module-info</groupId>
+                <artifactId>module-info</artifactId>
+                <version>2.1</version>
+                <executions>
+                    <execution>
+                        <id>module-info</id>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <moduleName>org.HdrHistogram</moduleName>
+                        </configuration>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.4.1</version>
@@ -101,7 +118,6 @@
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                            <Automatic-Module-Name>org.HdrHistogram</Automatic-Module-Name>
                         </manifest>
                     </archive>
                 </configuration>
@@ -152,6 +168,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
                 <configuration>
+                    <useModulePath>false</useModulePath>
                     <enableAssertions>false</enableAssertions>
                 </configuration>
             </plugin>
@@ -234,6 +251,53 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>test-jpms</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.13.0</version>
+                        <executions>
+                            <execution>
+                                <id>compile-java11-tests</id>
+                                <goals>
+                                    <goal>testCompile</goal>
+                                </goals>
+                                <configuration>
+                                    <compileSourceRoots>
+                                        <compileSourceRoot>${project.basedir}/src/test/java11</compileSourceRoot>
+                                    </compileSourceRoots>
+                                    <useModulePath>true</useModulePath>
+                                    <release>11</release>
+                                    <outputDirectory>${project.build.directory}/test-classes-11</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>test-java11</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <useModulePath>true</useModulePath>
+                                    <testClassesDirectory>${project.build.directory}/test-classes-11</testClassesDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>deploy</id>
             <build>

--- a/src/test/java11/module-info.java
+++ b/src/test/java11/module-info.java
@@ -1,0 +1,11 @@
+/**
+ * module-info.java
+ * Written by Gil Tene of Azul Systems, and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * @author Gil Tene
+ */
+open module test {
+    requires org.HdrHistogram;
+    requires org.junit.jupiter.api;
+}

--- a/src/test/java11/org.HdrHistogram.tests/ModularTest.java
+++ b/src/test/java11/org.HdrHistogram.tests/ModularTest.java
@@ -1,0 +1,33 @@
+/**
+ * ModularTest.java
+ * Written by Gil Tene of Azul Systems, and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * @author Gil Tene
+ */
+
+package org.HdrHistogram.tests;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+import org.HdrHistogram.Histogram;
+import java.lang.Module;
+
+public class ModularTest {
+
+    // Simplistic but ensure we can use the library from a modular application
+    @Test
+    public void smokeTest() {
+        Histogram histogram = new Histogram(5);
+        long res = histogram.getValueAtPercentile(50.0);
+        Assertions.assertEquals(0, res);
+    }
+
+    // We are an full fledge module
+    @Test
+    public void moduleTest() {
+        Module module = Histogram.class.getModule();
+        Assertions.assertEquals("org.HdrHistogram", module.getName());
+        Assertions.assertFalse(module.getDescriptor().isAutomatic());
+    }
+}


### PR DESCRIPTION
Motivation:

Support explicit Java modules in HdrHistogram while continue providing a Java 8 baseline. This aims to bring modularity to the Java ecosystem of libraries.

Changes:

Use the io.github.dmlloyd.module-info:module-info plugin that produces a module-info class file that can be used when HdrHistogram is used on the module path.

Tests have also been added, and is only executed with a Java 11 profile. These tests ensures that HdrHistogram can be used as a module on the module path and that it is actually in an explicit module.