### PR TITLE
Use Canonical URL of the CC0-1.0 license

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,10 @@
         <license>
             <comments>
                 * This code was Written by Gil Tene of Azul Systems, and released to the
-                * public domain, as explained at http://creativecommons.org/publicdomain/zero/1.0/
+                * public domain, as explained at https://creativecommons.org/publicdomain/zero/1.0/
             </comments>
             <name>Public Domain, per Creative Commons CC0</name>
-            <url>http://creativecommons.org/publicdomain/zero/1.0/</url>
+            <url>https://creativecommons.org/publicdomain/zero/1.0/</url>
         </license>
         <license>
             <name>BSD-2-Clause</name>


### PR DESCRIPTION
According to the webpage https://creativecommons.org/publicdomain/zero/1.0/ is the canonical form of the URL.

